### PR TITLE
Fixed fontspec issue on macOS

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -4,6 +4,8 @@
 \documentclass[a4paper,AutoFakeBold,oneside,12pt]{book}
 %需要区分奇偶页的（即每一章第一页一定在奇数页上）请使用下面一行
 %\documentclass[a4paper,AutoFakeBold,openright,12pt]{book}
+%若在MacOS上使用此模板请使用下面一行，可根据自行需要区分奇偶页
+%\documentclass[a4paper,AutoFakeBold,oneside,12pt,fontset=mac]{book}
 \usepackage{BUPTthesisbachelor}
 \usepackage{setspace}
 


### PR DESCRIPTION
## Progress
Fixed the fontspec `font-not-found` error on macOS, because of missing `FandolSong-Regular` font.

## Description
Previously, the console output on macOS was: 
```
fontspec error: "font-not-found"
!
! The font "FandolSong-Regular" cannot be found. 
! 
! See the fontspec documentation for further information.
.....
```
## Ending
This improvement will help a lot for macOS users with the annoying `fontspec` issue and finally passed the duplication test without any mistakes. So I think this is a practical approach for macOS users to compose their thesis in LaTeX better.
